### PR TITLE
Use `fs` to write to stdout + write larger buffers

### DIFF
--- a/yes.js
+++ b/yes.js
@@ -3,7 +3,9 @@ var msg = process.argv.length > 2 ? process.argv[2] : 'y';
 var fs = require('fs')
 var stdout = process.stdout.fd
 
-var buf = Buffer.from(msg + '\n')
+var BUFSIZ = 8192
+var repeats = Math.floor(BUFSIZ / (msg.length + 1))
+var buf = Buffer.from((msg + '\n').repeat(repeats))
 var len = buf.length
 var remaining = len
 

--- a/yes.js
+++ b/yes.js
@@ -1,9 +1,21 @@
 #!/usr/bin/env node
 var msg = process.argv.length > 2 ? process.argv[2] : 'y';
+var fs = require('fs')
+var stdout = process.stdout.fd
 
-while(1){
-  if(!process.stdout.write(msg + '\r\n')){
-    process.exit(0);
+var buf = Buffer.from(msg + '\n')
+var len = buf.length
+var remaining = len
+
+while (true) {
+  try {
+    var written = fs.writeSync(stdout, buf, null, remaining)
+    remaining -= written
+  } catch (err) {
+    // catch EAGAIN
+    if (err.code !== 'EAGAIN')
+      process.exit(1)
   }
-}
 
+  if (remaining === 0) remaining = len
+}


### PR DESCRIPTION
An alternative to #4 :) Feel free to take that instead (it was first after all),
I just wanted to try this out too :D

`process.stdout.write` writes to a Node.js stream, so it does a bunch of
work before anything is actually written. This patch uses `fs.writeSync`
to write to the stdout fd.

If you write a lot of stuff very fast `writeSync` will start throwing
EAGAIN errors. There might be a better way to wait for the file to be
writable again, but this patch just catches those errors and ignores
them. 

Using `fs` instead of `process.stdout.write` speeds it up by about 7x
for me, from just below 500KiB/s to 3.5~4MiB/s.

Buffering writes into batches of ~8192 bytes speeds it up even more,
because there are far fewer syscalls. With buffering I get around
4-5GiB/s writing to /dev/null.

![image](https://user-images.githubusercontent.com/1006268/27187244-f5a7696a-51ea-11e7-908c-e322869f8bbb.png)

compared to 6-7GiB/s for coreutils `yes`:

![image](https://user-images.githubusercontent.com/1006268/27187325-30136ebe-51eb-11e7-9834-e59bcd1ae438.png)